### PR TITLE
Added check for data type before creating property type

### DIFF
--- a/NicBell.UCreate/Attributes/PropertyAttribute.cs
+++ b/NicBell.UCreate/Attributes/PropertyAttribute.cs
@@ -41,7 +41,11 @@ namespace NicBell.UCreate.Attributes
 
         public PropertyType GetPropertyType()
         {
-            var propType = new PropertyType(new DataTypeSync().GetDataType(TypeName))
+            var dataType = new DataTypeSync().GetDataType(TypeName);
+            if(dataType == null)
+                throw new Exception($"Failed to find data type with name: {TypeName} for property: {Name}");
+
+            var propType = new PropertyType(dataType)
             {
                 Alias = Alias,
                 Name = Name,


### PR DESCRIPTION
This just helps to identify what data types are missing when performing a synchronisation.
