### PR TITLE
Create/synchronise data types first.

### DIFF
--- a/NicBell.UCreate/CmsSyncManger.cs
+++ b/NicBell.UCreate/CmsSyncManger.cs
@@ -37,15 +37,15 @@ namespace NicBell.UCreate
         /// </summary>
         private static void SynchronizeTypes()
         {
-            var dataSync = new DataTypeSync();
             var mediaSync = new MediaTypeSync();
+            var dataSync = new DataTypeSync();
             var docSync = new DocTypeSync();
             var memberSync = new MemberTypeSync();
             var memberGroupSync = new MemberGroupSync();
 
             //Sync all the types
-            dataSync.SyncAll();
             mediaSync.SyncAll();
+            dataSync.SyncAll();
             docSync.SyncAll();
             memberSync.SyncAll();
             memberGroupSync.SyncAll();


### PR DESCRIPTION
I started adding references to media types inside the data types. I do it to set the startNodeId (PreValues) of media pickers without hardcoding an ID.

In the following example, the `GetIdOfFirstWithTypeOrCreateAtRoot` function will return the ID of the first `BlogAuthorPictureFolder` it finds, or create one named "Authors" and return its ID.

```
public IDictionary<string, PreValue> PreValues => new Dictionary<string, PreValue>
{
    {"multiPicker", new PreValue("0")},
    {"onlyImages", new PreValue("1")},
    {"disableFolderSelect", new PreValue("1")},
    {
        "startNodeId",
        new PreValue(MediaUtils.GetIdOfFirstWithTypeOrCreateAtRoot(nameof(BlogAuthorPictureFolder), "Authors"))
    }
};
```

If that's OK with you, I'd like the media types to be synced first. After several tests, it doesn't seem to be causing any problem. Thanks!